### PR TITLE
Strict loading in solid queue

### DIFF
--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -26,7 +26,7 @@ module SolidQueue
 
       def release_one(concurrency_key)
         transaction do
-          if execution = ordered.where(concurrency_key: concurrency_key).limit(1).non_blocking_lock.first
+          if execution = ordered.includes(:job).where(concurrency_key: concurrency_key).limit(1).non_blocking_lock.first
             execution.release
           end
         end

--- a/app/models/solid_queue/execution.rb
+++ b/app/models/solid_queue/execution.rb
@@ -10,7 +10,7 @@ module SolidQueue
 
     scope :ordered, -> { order(priority: :asc, job_id: :asc) }
 
-    belongs_to :job, strict_loading: false
+    belongs_to :job
 
     class << self
       def type
@@ -77,7 +77,10 @@ module SolidQueue
     def discard
       SolidQueue.instrument(:discard, job_id: job_id, status: type) do
         with_lock do
-          job.destroy
+          SolidQueue::Job
+            .with_execution
+            .find(job_id)
+            .destroy
           destroy
         end
       end

--- a/app/models/solid_queue/failed_execution.rb
+++ b/app/models/solid_queue/failed_execution.rb
@@ -19,8 +19,9 @@ module SolidQueue
     end
 
     def retry
-      SolidQueue.instrument(:retry, job_id: job.id) do
+      SolidQueue.instrument(:retry, job_id: job_id) do
         with_lock do
+          job = SolidQueue::Job.find(job_id)
           job.reset_execution_counters
           job.prepare_for_execution
           destroy!

--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -4,7 +4,7 @@ module SolidQueue
   class Job < Record
     class EnqueueError < StandardError; end
 
-    include Executable, Clearable, Recurrable
+    include Executable, Clearable
 
     serialize :arguments, coder: JSON
 

--- a/app/models/solid_queue/job/concurrency_controls.rb
+++ b/app/models/solid_queue/job/concurrency_controls.rb
@@ -37,6 +37,10 @@ module SolidQueue
         blocked_execution.present?
       end
 
+      def blocked_execution
+        @blocked_execution ||= BlockedExecution.find_by(job_id: id)
+      end
+
       private
         def acquire_concurrency_lock
           return true unless concurrency_limited?

--- a/app/models/solid_queue/job/concurrency_controls.rb
+++ b/app/models/solid_queue/job/concurrency_controls.rb
@@ -6,7 +6,7 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        has_one :blocked_execution, strict_loading: false
+        has_one :blocked_execution
 
         delegate :concurrency_limit, :concurrency_duration, to: :job_class
 
@@ -14,6 +14,10 @@ module SolidQueue
       end
 
       class_methods do
+        def execution_associations
+          super.to_a.append(:blocked_execution)
+        end
+
         def release_all_concurrency_locks(jobs)
           Semaphore.signal_all(jobs.select(&:concurrency_limited?))
         end

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -104,6 +104,14 @@ module SolidQueue
         execution&.discard
       end
 
+      %w[ ready claimed failed ].each do |status|
+        define_method("#{status}_execution") do
+          return instance_variable_get("@#{status}_execution") ||
+            "SolidQueue::#{status.capitalize}Execution".safe_constantize.includes(:job).find_by(job_id: id)
+            .tap {|execution| instance_variable_set("@#{status}_execution", execution) 	}
+        end
+      end
+
       private
         def ready
           ReadyExecution.create_or_find_by!(job_id: id)

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -6,17 +6,22 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        include ConcurrencyControls, Schedulable, Retryable
+        include ConcurrencyControls, Schedulable, Retryable, Recurrable
 
-        has_one :ready_execution, strict_loading: false
-        has_one :claimed_execution, strict_loading: false
+        has_one :ready_execution
+        has_one :claimed_execution
 
         after_create :prepare_for_execution
 
         scope :finished, -> { where.not(finished_at: nil) }
+        scope :with_execution, -> { includes(execution_associations) }
       end
 
       class_methods do
+        def execution_associations
+          [:ready_execution, :claimed_execution]
+        end
+
         def prepare_all_for_execution(jobs)
           due, not_yet_due = jobs.partition(&:due?)
           dispatch_all(due) + schedule_all(not_yet_due)

--- a/app/models/solid_queue/job/recurrable.rb
+++ b/app/models/solid_queue/job/recurrable.rb
@@ -14,6 +14,10 @@ module SolidQueue
           super.to_a.append(:recurring_execution)
         end
       end
+
+      def recurring_execution
+        @recurring_execution ||= RecurringExecution.find_by(job_id: id)
+      end
     end
   end
 end

--- a/app/models/solid_queue/job/recurrable.rb
+++ b/app/models/solid_queue/job/recurrable.rb
@@ -6,7 +6,13 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        has_one :recurring_execution, strict_loading: false, dependent: :destroy
+        has_one :recurring_execution, dependent: :destroy
+      end
+
+      class_methods do
+        def execution_associations
+          super.to_a.append(:recurring_execution)
+        end
       end
     end
   end

--- a/app/models/solid_queue/job/retryable.rb
+++ b/app/models/solid_queue/job/retryable.rb
@@ -17,6 +17,10 @@ module SolidQueue
         end
       end
 
+      def failed_execution
+        @failed_execution ||= SolidQueue::FailedExecution.find_by(job_id: id)
+      end
+
       def retry
         failed_execution&.retry
       end

--- a/app/models/solid_queue/job/retryable.rb
+++ b/app/models/solid_queue/job/retryable.rb
@@ -6,9 +6,15 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        has_one :failed_execution, strict_loading: false
+        has_one :failed_execution
 
         scope :failed, -> { includes(:failed_execution).where.not(failed_execution: { id: nil }) }
+      end
+
+      class_methods do
+        def execution_associations
+          super.to_a.append(:failed_execution)
+        end
       end
 
       def retry

--- a/app/models/solid_queue/job/schedulable.rb
+++ b/app/models/solid_queue/job/schedulable.rb
@@ -6,12 +6,16 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        has_one :scheduled_execution, strict_loading: false
+        has_one :scheduled_execution
 
         scope :scheduled, -> { where(finished_at: nil) }
       end
 
       class_methods do
+        def execution_associations
+          super.to_a.append(:scheduled_execution)
+        end
+
         def schedule_all(jobs)
           schedule_all_at_once(jobs)
           successfully_scheduled(jobs)

--- a/app/models/solid_queue/job/schedulable.rb
+++ b/app/models/solid_queue/job/schedulable.rb
@@ -39,6 +39,10 @@ module SolidQueue
         scheduled_execution.present?
       end
 
+      def scheduled_execution
+        @scheduled_execution ||= ScheduledExecution.find_by(job_id: id)
+      end
+
       private
         def schedule
           ScheduledExecution.create_or_find_by!(job_id: id)

--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -3,8 +3,8 @@
 class SolidQueue::Process < SolidQueue::Record
   include Executor, Prunable
 
-  belongs_to :supervisor, class_name: "SolidQueue::Process", optional: true, inverse_of: :supervisees, strict_loading: false
-  has_many :supervisees, class_name: "SolidQueue::Process", inverse_of: :supervisor, foreign_key: :supervisor_id, strict_loading: false
+  belongs_to :supervisor, class_name: "SolidQueue::Process", optional: true, inverse_of: :supervisees
+  has_many :supervisees, class_name: "SolidQueue::Process", inverse_of: :supervisor, foreign_key: :supervisor_id
 
   store :metadata, coder: JSON
 
@@ -32,7 +32,7 @@ class SolidQueue::Process < SolidQueue::Record
       destroy!
 
       unless supervised? || pruned
-        supervisees.each(&:deregister)
+        SolidQueue::Process.where(supervisor_id: id).each(&:deregister)
       end
     rescue Exception => error
       payload[:error] = error

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -29,7 +29,7 @@ module Dummy
 
     config.active_job.queue_adapter = :solid_queue
 
-    config.active_record.strict_loading_by_default = true
+    config.active_record.strict_loading_by_default = true unless ENV['SKIP_STRICT_LOADING']
 
     if ENV["SEPARATE_CONNECTION"] && ENV["TARGET_DB"] != "sqlite"
       config.solid_queue.connects_to = { database: { writing: :primary, reading: :replica } }

--- a/test/integration/jobs_lifecycle_test.rb
+++ b/test/integration/jobs_lifecycle_test.rb
@@ -73,7 +73,7 @@ class JobsLifecycleTest < ActiveSupport::TestCase
     assert_equal 2, SolidQueue::Job.finished.count # 2 retries of A
     assert_equal 1, SolidQueue::FailedExecution.count
 
-    failed_execution = SolidQueue::FailedExecution.last
+    failed_execution = SolidQueue::FailedExecution.includes(:job).last
     failed_execution.job.retry
 
     wait_for_jobs_to_finish_for(3.seconds)

--- a/test/integration/recurring_tasks_test.rb
+++ b/test/integration/recurring_tasks_test.rb
@@ -15,7 +15,9 @@ class RecurringTasksTest < ActiveSupport::TestCase
     terminate_process(@pid) if process_exists?(@pid)
 
     SolidQueue::Process.destroy_all
-    SolidQueue::Job.destroy_all
+    SolidQueue::Job
+      .with_execution
+      .destroy_all
     SolidQueue::RecurringTask.delete_all
     JobResult.delete_all
   end

--- a/test/models/solid_queue/claimed_execution_test.rb
+++ b/test/models/solid_queue/claimed_execution_test.rb
@@ -78,7 +78,7 @@ class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
         SolidQueue::ReadyExecution.claim(job.queue_name, 1, process.id)
       end
 
-      SolidQueue::ClaimedExecution.last
+      SolidQueue::ClaimedExecution.includes(:process, :job).last
     end
 
     def with_error_subscriber(subscriber)

--- a/test/models/solid_queue/failed_execution_test.rb
+++ b/test/models/solid_queue/failed_execution_test.rb
@@ -28,7 +28,7 @@ class SolidQueue::FailedExecutionTest < ActiveSupport::TestCase
 
     assert_difference -> { SolidQueue::FailedExecution.count }, -1 do
       assert_difference -> { SolidQueue::ReadyExecution.count }, +1 do
-        SolidQueue::FailedExecution.last.retry
+        SolidQueue::FailedExecution.includes(:job).last.retry
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,7 @@ class ActiveSupport::TestCase
     end
 
     unless self.class.use_transactional_tests
-      SolidQueue::Job.destroy_all
+      SolidQueue::Job.with_execution.destroy_all
       SolidQueue::Process.destroy_all
       SolidQueue::Semaphore.delete_all
       SolidQueue::RecurringTask.delete_all

--- a/test/test_helpers/jobs_test_helper.rb
+++ b/test/test_helpers/jobs_test_helper.rb
@@ -4,7 +4,9 @@ module JobsTestHelper
   def wait_for_jobs_to_finish_for(timeout = 1.second, except: [])
     wait_while_with_timeout(timeout) do
       skip_active_record_query_cache do
-        SolidQueue::Job.where.not(active_job_id: Array(except).map(&:job_id)).where(finished_at: nil).any?
+        SolidQueue::Job
+          .with_execution
+          .where.not(active_job_id: Array(except).map(&:job_id)).where(finished_at: nil).any?
       end
     end
   end

--- a/test/test_helpers/processes_test_helper.rb
+++ b/test/test_helpers/processes_test_helper.rb
@@ -18,7 +18,7 @@ module ProcessesTestHelper
   end
 
   def assert_registered_processes(kind:, count: 1, supervisor_pid: nil, **attributes)
-    processes = skip_active_record_query_cache { SolidQueue::Process.where(kind: kind).to_a }
+    processes = skip_active_record_query_cache { SolidQueue::Process.includes(:supervisor).where(kind: kind).to_a }
     assert_equal count, processes.count
 
     if supervisor_pid
@@ -46,7 +46,7 @@ module ProcessesTestHelper
 
   def find_processes_registered_as(kind)
     skip_active_record_query_cache do
-      SolidQueue::Process.where(kind: kind)
+      SolidQueue::Process.includes(:supervisor).where(kind: kind)
     end
   end
 


### PR DESCRIPTION
Temp PR to gauge the level of effort required to enable strict loading in Solid Queue. 

Having all test pass was not trivial. I was able to have them pass with a temporary hack to bypass some Active Record association (see second commit 3607ae8c3c9fe7fb9a909c4e49e5dd1a5bd6bce1).

I believe it would be possible to have all test without this hack, but it would take more time and I am not sure it would be worth it as opposed to just turning off strict_loading on all associations explicitly. 